### PR TITLE
FanControl2

### DIFF
--- a/dvbapp2-plugins-po/fancontrol2/po/pl.po
+++ b/dvbapp2-plugins-po/fancontrol2/po/pl.po
@@ -1,15 +1,16 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: FanControl2\n"
-"POT-Creation-Date: 2012-11-04 15:20+Mitteleuropäische Zeit\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2014-06-29 07:06+0200\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Mariusz1970 <Mariusz1970@onet.eu>\n"
-"Language-Team: Mariusz1970 <Mariusz1970@onet.eu>\n"
+"Language-Team: joergm6 <Mariusz1970@onet.eu>\n"
+"Language: pl_PL\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: pl_PL\n"
-"X-Generator: Poedit 1.5.7\n"
+"X-Generator: Poedit 1.7\n"
 
 msgid "%s   %02d C"
 msgstr "%s   %02d C"
@@ -27,28 +28,28 @@ msgid "4Pin (PID)"
 msgstr "4Pin (PID)"
 
 msgid "Action in case of Fan failure"
-msgstr "Działanie w przypadku awarii wentylatora"
+msgstr "Działanie w przypadku awarii F.C.2"
 
 msgid "Auto-Delete Data older than (Days)"
 msgstr "Usuwanie plików starszych niż(Dni)"
 
 msgid "Auto-Delete older %s Days"
-msgstr "Automatycznie - usuń starszy % s Dni"
+msgstr "Automatycznie - usuń starsze % s Dni"
 
 msgid "Box Shutdown"
-msgstr "Wyłączyć DM "
+msgstr "Wyłącz odbiornik"
 
 msgid "Box has no fancontrol hardware -> FC2 deactivated"
-msgstr "w DM nie ma wentylatora -> F.C.2 wyłączony"
+msgstr "w odbiorniku nie ma wentylatora -> F.C.2 wyłączony"
 
 msgid "Box shutdown at Temperature (C)"
-msgstr "Zamknij DM w temperaturze (C)"
+msgstr "Wyłącz odbiornik przy temperaturze (C)"
 
 msgid "Cancel"
 msgstr "Anuluj"
 
 msgid "Check"
-msgstr "Kontrola"
+msgstr "Sprawdź"
 
 msgid "Choose path"
 msgstr "Wybierz ścieżkę"
@@ -66,37 +67,43 @@ msgid "Delete"
 msgstr "Usuń"
 
 msgid "Delete older 48h"
-msgstr "Usuń starszy 48h"
+msgstr "Usuń starsze 48h"
 
 msgid "Disk free : %d MByte"
 msgstr "Dysk wolny : % d MByte"
 
 msgid "Download"
-msgstr "Pobieranie"
+msgstr "Pobierz"
+
+msgid "Enable Console Logging"
+msgstr "Włącz rejestrowanie konsoli"
 
 msgid "Enable Data Logging"
-msgstr "Włączanie rejestrowania danych "
+msgstr "Włącz rejestrowanie danych"
 
 msgid "Enable Event Logging"
 msgstr "Włącz rejestrowanie zdarzeń"
 
+msgid "Enable Thread use"
+msgstr "Umożliwiaj wykorzystanie wątku"
+
 msgid "End temperature C"
-msgstr "Końcowa-Temp.C"
+msgstr "Temp. końcowa C"
 
 msgid "Extended Control Range"
-msgstr "Wzbogacona oferta sterowania"
+msgstr "Rozszerzony zakres regulacji"
 
 msgid "Fan is not working!"
 msgstr "Wentyl. nie pracuje!"
 
 msgid "Fan off in Idle Mode"
-msgstr "Wył.wentyl. w trybie czuwania?"
+msgstr "Wył.wentyl.w trybie czuwania?"
 
 msgid "Fan type"
 msgstr "Typ wentylatora"
 
 msgid "FanControl2 emergency, Box Shutdown now?"
-msgstr "FanControl2 awarja, wyłaczyć DM teraz?"
+msgstr "Awaria F.C.2 wyłączyć odbiornik teraz?"
 
 msgid "File %s does not exists"
 msgstr "Plik %s nie istnieje"
@@ -108,8 +115,8 @@ msgid ""
 "GUI needs a restart to apply the changes.\n"
 "Do you want to Restart the GUI now?"
 msgstr ""
-"GUI musi być uruchomione aby zastosować zmiany.\n"
-"czy chcesz uruchomić GUI teraz ?"
+"Trzeba zrestartować odbiornik,aby zastosować zmiany.\n"
+"Czy chcesz uruchomić GUI teraz ?"
 
 msgid "Help"
 msgstr "Pomoc"
@@ -124,10 +131,10 @@ msgid "Initial Voltage"
 msgstr "Pocz. Napięcie"
 
 msgid "Logging path"
-msgstr "Rejestrowanie ścieżki"
+msgstr "Ścieżka logów"
 
 msgid "Logging-Path: %s"
-msgstr "Ścieżka wpisania: %s"
+msgstr "Ścieżka -logów: %s"
 
 msgid "Max Fan %d rpm at PWM=255 (%s)"
 msgstr "Max Fan %d rpm w PWM=255 (%s)"
@@ -157,7 +164,7 @@ msgid "Min Fan Stop %d rpm at VLT=%d and PWM=0 (%s)"
 msgstr "Min Fan Stop %d rpm w VLT=%d i PWM=0 (%s)"
 
 msgid "Number of WebIF-Log-Entries"
-msgstr "Liczba WebIF-Logi-Wejście"
+msgstr "Numer Wpisu loga"
 
 msgid "PID Ctl Err %03.2f %%"
 msgstr "PID Ctl Err %03.2f %%"
@@ -166,7 +173,7 @@ msgid "PWM  %03d"
 msgstr "PWM  %03d"
 
 msgid "Restart GUI now?"
-msgstr "Restart GUI teraz?"
+msgstr "Zrestartować GUI teraz?"
 
 msgid "Save"
 msgstr "Zapisz"
@@ -175,13 +182,13 @@ msgid "Sensors"
 msgstr "Czujniki"
 
 msgid "Show Fan Speed as"
-msgstr "Prędkość obrotowa wentylatora"
+msgstr "Pokaż prędkość obrotów wentyl.jako"
 
 msgid "Show Monitor in Extension-Menu"
-msgstr "Pokaz Monitor w Rozszerzeniu - Menu "
+msgstr "Pokaż Monitor w Rozszerzonym Menu"
 
 msgid "Show Plugin in Extension-Menu"
-msgstr "Pokazu Plugin w Rozszerzeniu - Menu"
+msgstr "Pokaż Plugin w Rozszerzonym Menu"
 
 msgid "Speed"
 msgstr "Szybkość "
@@ -211,28 +218,28 @@ msgid "auto"
 msgstr "auto"
 
 msgid "below Tunerslot 4"
-msgstr "poniżej  Tunerslot 4"
+msgstr "poniżej głowicy 4"
 
 msgid "currentRPM:%d targetRPM:%d Temp:%4.1f"
-msgstr "prądRPM:%d docelowoRPM:%d Temp:%4.1f"
+msgstr "wartkośćRPM:%d docelowoRPM:%d Temp:%4.1f"
 
 msgid "disable DMM-FanControl"
-msgstr "DMM-Fancontrol wyłączyć"
+msgstr "wyłączyć Systemowy-M.F.?"
 
 msgid "disabled"
 msgstr "wyłączony"
 
 msgid "display Info"
-msgstr "pokaż informację"
+msgstr "wyświetl info."
 
 msgid "do nothing"
-msgstr "nie rób nic"
+msgstr "nic nie robić"
 
 msgid "increases overheating protection to (C)"
-msgstr "ochrona przed wzrostem przegrzania (C)"
+msgstr "ochrona przed wzrostem przegrzania w (C)"
 
 msgid "left near Card-Slot"
-msgstr "lewa strona niedaleko gniazda karty"
+msgstr "lewa strona niedaleko czytnika karty"
 
 msgid "left near Front-CI"
 msgstr "lewa strona blisko-przodu CI"
@@ -241,10 +248,10 @@ msgid "left of the Battery"
 msgstr "lewa strona koło baterii"
 
 msgid "max Speed rpm"
-msgstr "Max.Szybkość  rpm"
+msgstr "Max.Szybkość rpm"
 
 msgid "min Speed rpm"
-msgstr "Min.Szybkość  rpm"
+msgstr "Min.Szybkość rpm"
 
 msgid "near XILINX Spartan"
 msgstr "blisko XILINX Spartan"
@@ -256,10 +263,10 @@ msgid "no"
 msgstr "nie"
 
 msgid "not active"
-msgstr "nie aktywne"
+msgstr "nie aktywny"
 
 msgid "over Security Card"
-msgstr "ponad Security Card"
+msgstr "powyżej czytnika karty"
 
 msgid "please set fan type (3Pin or 4Pin)"
 msgstr "Proszę ustawić typ wentylatora (3Pin albo 4Pin)"
@@ -268,13 +275,13 @@ msgid "please wait (until 3min)..."
 msgstr "Proszę czekać (do 3min)..."
 
 msgid "press Info for HDD-Temp"
-msgstr " Info o HDD-temp"
+msgstr "Info o temp.HDD"
 
 msgid "read HDD-Temperature in HDD-Standby-Mode"
-msgstr "czytaj temperaturę HDD-tryb gotowości"
+msgstr "czytaj temperaturę HDD w trybie czuwania"
 
 msgid "readme.txt"
-msgstr "readme.txt"
+msgstr "przeczytaj.txt"
 
 msgid "turn off"
 msgstr "wyłączyć"
@@ -286,10 +293,10 @@ msgid "under the Fan"
 msgstr "pod wentylatorem"
 
 msgid "under the WLAN"
-msgstr "pod WLAN "
+msgstr "pod kartą WLAN "
 
 msgid "yes"
 msgstr "tak"
 
 msgid "yes, Except for Recording or HDD"
-msgstr "tak,z wyjątkiem nagrywania na HDD"
+msgstr "wyjątek,nagrywanie na HDD"


### PR DESCRIPTION
please add an update and please add a file called - przeczytaj.txt - with content:

===========================================================
FanControl2 by joergm6                          Hilfe V.2.4
Support-Forum: IHAD
Danksagungen: diddsen, _marv_, DreamKK
              Spaeleus(it), mimi74(fr), Bschaar(nl)
===========================================================
 Przeproszam,jezeli engielski przeklad nie jest calkowicie poprawny.
(celowo sa pominiete polskie znaki)
   
   Funkcje
   --------
Kontrola 3pinowego lub 4pinowego wentylator (PWM) zalezna od
sredniej dwoch najwyzszych temparatur.
Regulacja nastepuje w wolnym tepie, gdyz temperatura tez nie
zmienia sie gwaltownie i unikamy w ten sposob 
niepotrzebnego obciazenia procesora CPU.

##############################################################
   Funkcje bezpieczenstwa
   ---------------------
Jesli wentylator nie poda predkosci obrotow w ciagu 20 min. 
bedzie on uwazany za uszkodzony i bedzie sie pojawial odpowiedni
kumunikat na ekranie telewizora.
Jesli w trybie gotowosci bedzie wentylator wylaczony i bedzie 
przekroczona maksymalna temperatura - zostanie wentylator wlaczony. 
Jesli temperatura spadnie o wiecej niz 3°C zostanie on znow 
wylaczony.
Wentylator pracuje w pierwszych 10 minutach na minimalnej
predkosc.
Ochrona przed przegrzaniem moze byc zwiekszona nawet o 9°C.
Mozna tez ustawic czy Box ma sie wylaczyc i przy jakiej
temperaturze bac awarii wentylatora.

##############################################################
   Ustawienia
   -------------
   Wentylator wylaczony w trybie gotowosci
Tak = wentylator jest wylaczony, gdy Box jest w stanie gotowosci
Tak, z wyjatkiem podczas nagrywania na HDD = wentylator wylaczony 
w trybie czuwania, gdy nie nagrywamy i dysk jest w trybie uspienia.

   Predkosc min.
Temperatura jest "temperatura gotowosci" i ponizej jej
ustawienia predkosci obrotow regulacji.

   Predkosc max.
Temperatura jest "temperatura koncowa" i powyzej jej
ustawienia predkosci obrotow regulacji.

   Spokojna Temperatura
Do tej Temperatury nie bedzie regulacji
i bedzie ustawiona predkosc minimalna.

   Temperatura koncowa
Jest to maksymalna temperatura, ktora moze wystapic -gdy bedzie osiagnieta, 
bedzie ustawiona maksymalna predkosc.

   Napiecie poczatkowe i PWM
Przy zmianach tych wartosci bedzie rowniez niezwlocznie
wentylator ustawiony. Moga byc odrazu odczytane wartosci z
predkosci obrotow wentylatora.
Rozporzadzenie jest jednak natychmiastowe, a wiec
wystarczy spojrzec na obroty i wartosci mozna odrazu zmieniac.
Wartosci te sa wylaczone, gdy Box startuje lub
gdy wentylator zostal wylaczony w "trybie gotowosci".
  
   do wentylatorow typu 3pin
Napiecie sterowania wentylatora 3-pin jest ustawione
z sygnalem predkosci. Kontrolowane, tylko napiecia.
Ustawienia dla PWM nie maja kontroli.
Ustaw napiecie na jakas wartosc, ktorej obroty beda odpowiednie,
dla obrotow poczatkowych wentylatora po starcie Boxa.
Od tej predkosci beda juz obroty regulowane.

   do wentylatorow typu 4pin
Do regulacji(PWM) 4-pinowego
wentylatora. Najpierw ustawienia wartosc PWM. Jak nie
wystarcza zakres regulacji, mozna regulowac napieciem. 
Regulacja napiecia jest konieczna.
Ustaw napiecie do wartosci maksymalnej (na DM500HD
5-10). Ale takze nizsza wartosc napiecia jest znaczaca.
Nizsze napiecie oznacza nizsza maksymalna jak i
minimalna predkosc obrotow. Ustaw napiecie tak aby PWM bylo 
optymalne dla maxymalnych jak i minimalnych obrotow.
Istnieja rowniez wentylatory, ktore obracaja sie w PWM = 0 za szybko.
Zmniejszamy napiecie, az do mommentu gdzie
predkosc zostanie osiagnieta (również 0 jest mozliwe). Ale trzeba tez
miec obnizenie maksymalnej predkosci na uwadze.
PWM zapewnia wartosci odpowiadajacej predkosci obrotowej,
dla obrotow poczatkowych wentylatora po starcie Boxa.
Od tej predkosci beda juz obroty regulowane.

   dla Wentylatorow typ Ustawienia Wylaczone
Kontrola jest wylaczona. Wentylator pracuje z 
ustawionymi ostatnimi wartosciami.
Wentylator nie wylacza sie.

################################################################
    Sprawdzic
    ------
Tutaj jest proba, minimalnej predkosci wentylatora
kiedy wentylator przy minimalnym napieciu sie wylaczy.
Okreslona zostaje predkosc minimalna wentylatora.
Podobnie zostaje ustalona predkosc maksymalna
wentylatora. (OK) wartosc nie odpowiada ustawieniom
w (!!) nie pasuja do ustawienia wartosci wentylatora.
Zobacz osiagalne wartosci. Te szczegoly sa dla informacji
i nie ma to wplywu na kontrole mozliwosci.
Dla 4pinowych wentylatorow beda dodatkowe informacje pokazane,
ktore znajduja sie na "rozszerzeniach ustawien".
Zakres sterowania. Oznacza to, ze jest on w PWM-obszarze,
ponadto tez zmiane napiecia.

#################################################################
    Monitorowanie temperatury
    ------------------
Uzycie przycisku "Info" - beda wyswietlone poszczegolne informacje
temperatur Boxa.
Nacisnij przycisk "info" dla jednego odczytu temperatury HDD.

#################################################################
   Specjalne ustawienia
   -------------
Naciskajac przycisk "Menu", mozna poszczegolne wartosci zdefiniowac.
Skarga o awarii wentylatora [Pokaz Info]
  Wiadomosc o awarii wentylatora, czy ma Box sie
  wylaczyc czy nie robic nic
Box wylaczyc przy temperaturze (C) [65]
  Po osiagnieciu okreslonej temperatury, Box wylaczyc
  OFF (Deep Standby).
Przegrzanie zwiekszenie ochrony o (C) [0]
  Jesli wentylator jest wylaczony, w trybie Standby, bedzie 
  maksymalna temperatura osiagnieta - box wylaczyc.
  Ta maksymalna temperature mozna zwiekszyc do 9°C
Temperatura HDD w trybie gotowosci HDD czytac [AUTO]
  Tak = temperatura HDD czytac tez w trybie gotowosci HDD
  Nie = temperatura HDD czytac tylko gdy HDD aktywny
  Auto = przy starcie Boxa FC2 bedzie testowany tylko raz czy HDD
         uruchamia sie, i jesli tak zostanie wylaczone czytanie
  Nigdy = odczyt temperatury HDD deaktywowany - wylaczony
DMM fancontrol wylaczone [Nie]
  Pojawi sie w skorce z temperatura, DMM
  Sterowanie wentylatora aktywne, a takze wlacza wentylator.
  Beda spowodowane niechciane wlacz / wylacz propozycje.
  Zalecene: Wylacz wentylator DMM
Pokaz Monitor rozszerzenia menu [Tak]
  Obserwuj w rozszerzonym menu wyswietlacza (dlugi niebieski przycisk).
Liczba webIF wpisów  [40]
  Ile wydarzen mozna zobaczyc w webIF.
  40-999
Folder wydarzen
  Wybierz "OK", aby wybrac miejsce, w ktorym pliki wydarzen
  powinno byc zapisywane. Dane moga byc zapisywane, jezeli co najmniej
  10 MByte sa jeszcze wolne.
Wlacz rejestrowanie danych
  Kazda minuta jest zapis w FC2data.csv pliku
  zapisana. Mozna to na przyklad wywolywac bezposrednio w programie Excel.
  Jesli ten plik nie istnieje, a jest ta
  opcja wlaczona, plik bedzie generowany do
  okolo 4 kB na godzinę
Automatyczne usuwanie danych starszych niz (dni) [Nie]
  Rejestrowanie danych dane starsze niz tej liczbie
  beda usuniete.
  Wykonac: codziennie o 00:00 i przy starcie Enigmy ( GUI )
Wlacz rejestrowanie zdarzen
  Bedzie kazde zdarzenie w FC2events.txt pliku
  zapisywane.
  ok. 30kByte w kazda godzine
  
 ###############################################################
    Interfejs Web
    -------------
Wejdz na: http://dreamboxip/fancontrol
Wyswietla informacje na temat aktualnych wartosci i ostatnich
protokolach. Co kazda godzine wyswietlane zostana 
wiadomosci o wartosciach temperatury predkosciach wentylatora.
Z "FC2 Log", pliki sa pobierane i rejestrowania mozna ustawic.
"Wykres FC2" pokazuje on-line diagramy w ciagu ostatnich 48 godzin.
Logging musi byc wlaczony, aby bylo to mozliwe. Musza byc przynajmniej 
2.5h te dane dostepne!
W przypadku korzystania z przegladarki Firefox, moze sie zdarzyc, ze diagram
nie bedzie wyswietlany poprawnie. Nastepne i dodatkowe
odswiezania (F5) nie jest konieczne.

##############################################################
    Inne
    ---------
Wszystkie wentylatory wazne biezace odczyty
wyswietlane w postaci wykresu i wartosciach. 
Slupkowy wykres jest wyswietlany na podstawie parametrow.
FanControl2 jest przygotowany na rozne jezyki.
Plik POT dla ipkg - jesli ktos inne jezyki
chce udostępnic.
Ustawienia sa w normalnych Enigma2 ustawieniach
przechowywane i dlatego sa w kopii zapasowej / przywracania wlacznie.

tlumaczenie-kol.MiroMoni

===========================================================

This is file- readme.txt  - translated into Polish